### PR TITLE
Keep mapping from character name to their width for the 14 standard fonts

### DIFF
--- a/pdfafm.ml
+++ b/pdfafm.ml
@@ -77,7 +77,10 @@ let get_tables lines =
              let p = lookup_charnum charmetrics_hash n
              and p' = lookup_charnum charmetrics_hash n' in
              if p > -1 && p' > -1 then Some (p, p', kern) else None)
-          kerns
+          kerns,
+        option_map
+        (fun (name, (_, w)) -> Some (name, w))
+          charmetrics
 
 let read i =
   try
@@ -85,4 +88,3 @@ let read i =
       get_tables lines
   with
     e -> failwith (Printexc.to_string e)
-

--- a/pdfafm.mli
+++ b/pdfafm.mli
@@ -6,3 +6,4 @@ raise [Failure]. *)
 val read :
   Pdfio.input ->
   (string * string) list * (int * int) list * (int * int * int) list
+  * (string * int) list (* charname -> width *)

--- a/pdfstandard14.ml
+++ b/pdfstandard14.ml
@@ -2,10 +2,11 @@
 open Pdfutil
 
 let read_afm afm =
-  let headers, ws, ks = Pdfafm.read (Pdfio.input_of_string afm) in
+  let headers, ws, ks, ws' = Pdfafm.read (Pdfio.input_of_string afm) in
     hashtable_of_dictionary headers,
     hashtable_of_dictionary ws,
-    hashtable_of_dictionary (map (fun (c, c', k) -> (c, c'), k) ks)
+    hashtable_of_dictionary (map (fun (c, c', k) -> (c, c'), k) ks),
+    hashtable_of_dictionary ws'
 
 (* Main functions *)
 let tables =
@@ -58,7 +59,7 @@ let rec width dokern widths kerns = function
 
 (* The main function. Give a font and the text string. *)
 let textwidth dokern f s =
-  let _, widths, kerns = lookup_failnull f tables () in
+  let _, widths, kerns, _ = lookup_failnull f tables () in
     width dokern widths kerns (map int_of_char (explode s))
 
 (* Return the AFM table data itself *)
@@ -91,4 +92,3 @@ let flags_of_standard_font = function
   | Pdftext.CourierOblique
   | Pdftext.CourierBoldOblique -> 33
   | _ -> 32
-

--- a/pdfstandard14.mli
+++ b/pdfstandard14.mli
@@ -9,16 +9,18 @@ to place it vertically centered around the y coordinate, rather than with the
 baseline at that y coordinate. *)
 val baseline_adjustment : Pdftext.standard_font -> int
 
-(** The data extracted from the font AFM. This is a triple, consisting of a
-table of header pairs, a table of (character number, width) pairs and a table
-of (first, second, kern) triples representing the kerning table. *)
+(** The data extracted from the font AFM. This is a 4-tuple, consisting of a
+table of header pairs, a table of (character number, width) pairs, a table
+of (first, second, kern) triples representing the kerning table and a table
+of (character name, width) pairs.  The last table is useful for character which
+are identified with a custom encoding and which might not be assigned a number
+in the standard encoding. *)
 val afm_data :
   Pdftext.standard_font ->
-    (string, string) Hashtbl.t * (int, int) Hashtbl.t * (int * int, int) Hashtbl.t
+    (string, string) Hashtbl.t * (int, int) Hashtbl.t * (int * int, int) Hashtbl.t * (string, int) Hashtbl.t
 
 (** Return a suitable StemV value for a standard font *)
 val stemv_of_standard_font : Pdftext.standard_font -> int
 
 (** Return a suitable flags value for a standard font *)
 val flags_of_standard_font : Pdftext.standard_font -> int
-


### PR DESCRIPTION
Currently, the AFM font parser only returns metrics based on character code.  But a PDF document can refer to other characters defined in the font (using custom encoding, referring to font characters based on their glyph name).  This PR keeps the width information indexed by character name.  (Something similar should probably be done for kerning.)