### PR TITLE
Switch to safe-string mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ LIBINSTALL_FILES = camlpdf.a camlpdf.cma camlpdf.cmxa libcamlpdf_stubs.a \
 dllcamlpdf_stubs.* $(foreach x,$(PDFMODS),$x.mli) \
 $(foreach x,$(PDFMODS),$x.cmi) $(foreach x,$(PDFMODS),$x.cmx)
 
-OCAMLNCFLAGS = -g -unsafe-string -annot -w -3
-OCAMLBCFLAGS = -g -unsafe-string -annot -w -3
+OCAMLNCFLAGS = -g -safe-string -annot -w -3
+OCAMLBCFLAGS = -g -safe-string -annot -w -3
 OCAMLLDFLAGS = -g
 
 all : native-code-library byte-code-library htdoc
@@ -27,4 +27,3 @@ clean ::
 install : libinstall
 
 -include OCamlMakefile
-

--- a/pdfcodec.ml
+++ b/pdfcodec.ml
@@ -242,17 +242,17 @@ let flate_process f data =
   and inlength = bytes_size data in
     let input =
       (fun buf ->
-         let s = String.length buf in
+         let s = Bytes.length buf in
            let towrite = min (inlength - !pos) s in
              for x = 0 to towrite - 1 do
-               String.unsafe_set
+               Bytes.unsafe_set
                  buf x (Char.unsafe_chr (bget_unsafe data !pos));
                  incr pos
              done;
              towrite)
     and output =
       (fun buf length ->
-         if length > 0 then strings =| String.sub buf 0 length)
+         if length > 0 then strings =| Bytes.sub_string buf 0 length)
     in
       f input output;
       bytes_of_strings_rev !strings
@@ -264,17 +264,17 @@ let decode_flate_input i =
   let strings = ref [] in
     let input =
       (fun buf ->
-         let s = String.length buf in
+         let s = Bytes.length buf in
            if s > 0 then
              begin
                match i.input_byte () with
                | x when x = Pdfio.no_more -> raise End_of_file
-               | x -> String.unsafe_set buf 0 (char_of_int x); 1
+               | x -> Bytes.unsafe_set buf 0 (char_of_int x); 1
              end
            else 0)
     and output =
       (fun buf length ->
-         if length > 0 then strings =| String.sub buf 0 length)
+         if length > 0 then strings =| Bytes.sub_string buf 0 length)
     in
       Pdfflate.uncompress input output;
       bytes_of_strings_rev !strings

--- a/pdfflate.ml
+++ b/pdfflate.ml
@@ -14,14 +14,14 @@ type flush_command =
 
 external deflate_init: int -> bool -> stream = "camlzip_deflateInit"
 external deflate:
-  stream -> string -> int -> int -> string -> int -> int -> flush_command
+  stream -> bytes -> int -> int -> bytes -> int -> int -> flush_command
          -> bool * int * int
   = "camlzip_deflate_bytecode" "camlzip_deflate"
 external deflate_end: stream -> unit = "camlzip_deflateEnd"
 
 external inflate_init: bool -> stream = "camlzip_inflateInit"
 external inflate:
-  stream -> string -> int -> int -> string -> int -> int -> flush_command
+  stream -> bytes -> int -> int -> bytes -> int -> int -> flush_command
          -> bool * int * int
   = "camlzip_inflate_bytecode" "camlzip_inflate"
 external inflate_end: stream -> unit = "camlzip_inflateEnd"
@@ -29,8 +29,8 @@ external inflate_end: stream -> unit = "camlzip_inflateEnd"
 let buffer_size = 1024
 
 let compress ?(level = 6) ?(header = true) refill flush =
-  let inbuf = String.create buffer_size
-  and outbuf = String.create buffer_size in
+  let inbuf = Bytes.create buffer_size
+  and outbuf = Bytes.create buffer_size in
   let zs = deflate_init level header in
   let rec compr inpos inavail =
     if inavail = 0 then begin
@@ -53,8 +53,8 @@ let compress ?(level = 6) ?(header = true) refill flush =
 
 
 let uncompress ?(header = true) refill flush =
-  let inbuf = String.create buffer_size
-  and outbuf = String.create buffer_size in
+  let inbuf = Bytes.create buffer_size
+  and outbuf = Bytes.create buffer_size in
   let zs = inflate_init header in
   let rec uncompr inpos inavail =
     if inavail = 0 then begin

--- a/pdfflate.mli
+++ b/pdfflate.mli
@@ -12,11 +12,10 @@ bytes written. The optional argument [level] gives the zlib compression level
 zlib header (the default is [true]). *)
 val compress:
   ?level: int -> ?header: bool ->
-  (string -> int) -> (string -> int -> unit) -> unit
+  (bytes -> int) -> (bytes -> int -> unit) -> unit
 
 (** Uncompress data. The input and output functions are as described for
 [compress]. If [header] is [true], a zlib header is expected (the default is
 [true]). *)
 val uncompress:
-  ?header: bool -> (string -> int) -> (string -> int -> unit) -> unit
-
+  ?header: bool -> (bytes -> int) -> (bytes -> int -> unit) -> unit

--- a/pdfgenlex.ml
+++ b/pdfgenlex.ml
@@ -56,7 +56,7 @@ let lex_item s =
       try
         match String.unsafe_get s 0 with
         | 'a'..'z' | 'A'..'Z' ->
-            LexName (String.copy s)
+            LexName s
         | '\"' when len >= 2 ->
             LexString (String.sub s 1 (len - 2))
         | _ ->
@@ -73,7 +73,7 @@ let lex_item s =
                   end
                 else LexReal (float_of_string s)
       with
-        _ -> LexName (String.copy s)
+        _ -> LexName s
 
 (* Return the string between and including the current position and before the
 next character satisfying a given predicate, leaving the position at the
@@ -91,31 +91,15 @@ let rec lengthuntil i n =
 float_of_string etc. What we actually need is int_of_substring etc, but this
 will require patching OCaml. *)
 let strings =
- [|"";
-   " ";
-   "  ";
-   "   ";
-   "    ";
-   "     ";
-   "      ";
-   "       ";
-   "        ";
-   "         ";
-   "          ";
-   "           ";
-   "            ";
-   "             ";
-   "              ";
-   "               ";
-   "                "|]
+  Array.init 17 (fun i -> Bytes.make i ' ')
 
 let getuntil i =
   let p = i.Pdfio.pos_in () in
     let l = lengthuntil i 0 in
       i.Pdfio.seek_in p;
-      let s = if l <= 16 then Array.unsafe_get strings l else String.create l in
+      let s = if l <= 16 then Array.unsafe_get strings l else Bytes.create l in
         Pdfio.setinit_string i s 0 l;
-        s
+        Bytes.to_string s
 
 (* The same, but don't return anything. *)
 let rec ignoreuntil f i =

--- a/pdfio.mli
+++ b/pdfio.mli
@@ -47,6 +47,9 @@ type output =
 (** A distinguished byte value indicating "no more input" *)
 val no_more : int
 
+(** An alias to OCaml built-in [bytes] type. *)
+type caml_bytes = bytes
+
 (** The type of fast to access but possibly very large arrays of bytes. *)
 type bytes
 
@@ -143,13 +146,16 @@ val bset_unsafe : bytes -> int -> int -> unit
 val setinit : input -> bytes -> int -> int -> unit
 
 (** [setinit_string i s o l] sets s o...o + l - 1 from the input *)
-val setinit_string : input -> string -> int -> int -> unit
+val setinit_string : input -> caml_bytes -> int -> int -> unit
 
 (** [setinit_bytes i o l] gives a [bytes] with s o...o + l - 1 from the input *)
 val bytes_of_input : input -> int -> int -> bytes
 
 (** Make bytes from a string. *)
 val bytes_of_string : string -> bytes
+
+(** Make bytes from ocaml bytes. *)
+val bytes_of_caml_bytes : caml_bytes -> bytes
 
 (** Make bytes from a list of integers, each between 0 and 255. *)
 val bytes_of_list : int list -> bytes
@@ -256,4 +262,3 @@ val bytes_of_write_bitstream : bitstream_write -> bytes
 
 (** Debug the next [n] chars to standard output and then rewind back *)
 val debug_next_n_chars : int -> input -> unit
-

--- a/pdfpage.ml
+++ b/pdfpage.ml
@@ -957,9 +957,12 @@ let postpend_operators pdf ops ?(fast=false) page =
 let next_string s =
   if s = "" then "a" else
     if s.[0] = 'z' then "a" ^ s else
-      let s' = String.copy s in
-         s'.[0] <- char_of_int (int_of_char s'.[0] + 1);
-         s'
+      String.mapi
+        (fun i c ->
+           if i = 0 then char_of_int (int_of_char c + 1)
+           else c
+        )
+        s
 
 (* True if one string [p] is a prefix of another [n] *)
 let is_prefix p n =
@@ -1130,4 +1133,3 @@ let add_prefix pdf prefix =
        | _ -> obj)
     pdf(*;
     Printf.eprintf "***add_prefix has concluded\n";*)
-

--- a/pdfread.ml
+++ b/pdfread.ml
@@ -380,8 +380,7 @@ reaching past the end of a file, in which case an exception is raised. *)
 let read_chunk n i =
   try
     let orig_pos = i.pos_in () in
-      let s = String.create n in
-        for x = 0 to n - 1 do s.[x] <- unopt (i.input_char ()) done;
+      let s = String.init n (fun _ -> unopt (i.input_char ())) in
         i.seek_in orig_pos;
         s
   with

--- a/pdfutil.ml
+++ b/pdfutil.ml
@@ -254,19 +254,17 @@ let explode s =
 
 (* Make a string from a list of characters, preserving order. *)
 let implode l =
-  let s = String.create (length l) in
+  let s = Bytes.create (length l) in
     let rec list_loop x = function
        [] -> ()
-     | i::t -> String.unsafe_set s x i; list_loop (x + 1) t
+     | i::t -> Bytes.unsafe_set s x i; list_loop (x + 1) t
     in
       list_loop 0 l;
-      s
+      Bytes.to_string s
 
 (* String of character. *)
 let string_of_char c =
-  let s = String.create 1 in
-    String.unsafe_set s 0 c;
-    s
+  String.make 1 c
 
 (* Long-integer function abbreviations *)
 let i32ofi = Int32.of_int

--- a/pdfwrite.ml
+++ b/pdfwrite.ml
@@ -772,4 +772,3 @@ let pdf_to_file pdf f =
   pdf_to_file_options
     ~preserve_objstm:true ~generate_objstm:false ~compress_objstm:true
     false None true pdf f
-


### PR DESCRIPTION
Context: https://github.com/ocaml/ocaml/pull/1859 reports camlpdf as one of the last projects on OPAM requiring the unsafe-string mode.  Since this mode might go away at some point, or at least not be supported with the default configure-time mode, it is time to adapt camlpdf!

I've chosen to minimize the changes to the public API of camlpdf.  In particular, the type Pdfio.bytes keeps its name, exposing a new Pdfio.caml_bytes as an alias to the built-in `bytes` type.  I wrote a first version using a different approach (renaming Pdfio.bytes to Pdfio.pdfbytes), but I think the current version is better.

Which versions of OCaml are supposed to be supported by camlpdf? There is a package emulating "Bytes" in OPAM, but I've used e.g. String.mapi (introduced in 4.02) in this PR.