### PR TITLE
Drop label which is never used on call sites

### DIFF
--- a/pdfutil.ml
+++ b/pdfutil.ml
@@ -679,7 +679,7 @@ let rec lose_inner prev p = function
 let lose p = lose_inner [] p
 
 (* Make a list of length [n] with each element equal to [x]. *)
-let many x ~n =
+let many x n =
   Array.to_list (Array.make n x)
 
 (* A version where we need to apply unit each time, for instance when producing

--- a/pdfutil.mli
+++ b/pdfutil.mli
@@ -243,7 +243,7 @@ matching a predicate. *)
 val lose : ('a -> bool) -> ('a list -> 'a list)
 
 (** [many x n] makes a list of length [n] with each element equal to [x]. *)
-val many : 'a -> n:int -> 'a list
+val many : 'a -> int -> 'a list
 
 (** A version where we need to apply unit each time, for instance when producing
 a list of random numbers. Result is ordered. *)


### PR DESCRIPTION
Pdfutil declares a label `~n` which is never used.  This PR proposes to remove it, which would allow enabling warning 6 for the project (not done in this PR).  (This was discovered while upgrading the version of camlpdf vendored in our mono-repo which uses a different build system.)