### PR TITLE
Handle empty cross-reference streams

### DIFF
--- a/pdfread.ml
+++ b/pdfread.ml
@@ -1196,7 +1196,7 @@ let read_xref_stream i =
           begin try
             if !read_debug then
               (Printf.eprintf "About to start read_xref_stream\n%!"; tt' ());
-            while true do xrefs =| read_xref_line_stream i' w1 w2 w3 done
+            while Pdfio.peek_byte i' <> Pdfio.no_more do xrefs =| read_xref_line_stream i' w1 w2 w3 done
 
           with
             _ ->

--- a/pdfread.ml
+++ b/pdfread.ml
@@ -1098,6 +1098,8 @@ let read_xref i =
 the lengths in bytes of each of the three fields. *)
 let read_xref_line_stream i w1 w2 w3 =
   assert (w1 >= 0 && w2 >= 0 && w3 >= 0);
+  if (w1 = 0 && w2 = 0 && w3 = 0) then
+    raise (Pdf.PDFError (Pdf.input_pdferror i "Bad Xref stream"));
   try
     let read_field bytes =
       let rec read_field bytes mul =
@@ -1196,7 +1198,7 @@ let read_xref_stream i =
           begin try
             if !read_debug then
               (Printf.eprintf "About to start read_xref_stream\n%!"; tt' ());
-            while Pdfio.peek_byte i' <> Pdfio.no_more do xrefs =| read_xref_line_stream i' w1 w2 w3 done
+            while true do xrefs =| read_xref_line_stream i' w1 w2 w3 done
 
           with
             _ ->


### PR DESCRIPTION
When a (malformed) PDF contains an empty cross-reference stream, camlpdf will get stuck in an infinite loop when attempting to iterate over it. This change checks the stream for EOF before attempting to read xref lines.

Example PDF: [empty-xref-stream.pdf](https://github.com/johnwhitington/camlpdf/files/7936715/empty-xref-stream.pdf)
